### PR TITLE
Introduce karma

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,6 +51,9 @@ export default async (bot: Telegraf<Context>) => {
   bot.command('/quiz', commands.quiz);
   bot.hears(/^(\!qz).*$/, commands.quiz);
 
+  bot.command('/karma', commands.karma);
+  bot.hears(/^(\!k).*$/, commands.karma);
+
   bot.on('inline_query', handlers.inlineQuery);
   bot.on('poll_answer' as any, handlers.pollAnswer);
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ import { printHelp } from './help';
 import { resolveRexpl } from './resolve';
 import { toggleReaction } from './reaction';
 import { startQuiz } from './quiz';
+import { getKarma } from './karma';
 
 export default {
   add: createExpl,
@@ -17,4 +18,5 @@ export default {
   resolve: resolveRexpl,
   reaction: toggleReaction,
   quiz: startQuiz,
+  karma: getKarma,
 };

--- a/src/commands/karma.ts
+++ b/src/commands/karma.ts
@@ -1,0 +1,9 @@
+import * as _ from 'lodash';
+import * as db from '../database';
+import type { Context } from '../types/telegraf';
+import * as messages from '../constants/messages';
+
+export async function getKarma(ctx: Context) {
+  const karma = await db.getUserKarma(ctx.from!.id);
+  return ctx.reply(messages.karma.display(karma));
+}

--- a/src/commands/reaction.ts
+++ b/src/commands/reaction.ts
@@ -33,7 +33,7 @@ export async function toggleReaction(ctx: Context) {
       +id,
       reaction,
     );
-    ctx.answerCbQuery(messages.reaction.added(reaction));
+    await ctx.answerCbQuery(messages.reaction.added(reaction));
   } catch (err) {
     switch (err.message) {
       case 'already_exists':

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -75,3 +75,7 @@ export const quiz = {
     'There needs to be atleast one more expls to create a quiz',
   ),
 };
+
+export const karma = {
+  display: template('Your karma: {0}'),
+};

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,7 +8,7 @@ const logger = new Logger(__filename);
 
 type KarmaStatColumn = 'likes' | 'dislikes' | 'echos';
 
-const karmaTableMapping: { [key: string]: KarmaStatColumn } = {
+const karmaColumnMapping: { [key: string]: KarmaStatColumn } = {
   '👍': 'likes',
   '👎': 'dislikes',
 };
@@ -305,10 +305,10 @@ export async function addReaction(
       reaction,
     });
 
-    if (karmaTableMapping[reaction]) {
+    if (karmaColumnMapping[reaction]) {
       const expl = await knex('expls').where({ id: id }).first();
       if (expl.user_id != from.user) {
-        await addKarmaStat(expl.user_id, karmaTableMapping[reaction], 1);
+        await addKarmaStat(expl.user_id, karmaColumnMapping[reaction], 1);
       }
     }
 
@@ -342,10 +342,10 @@ export async function deleteReaction(
 
     logger.debug('Reaction deleted', { id: explId, reaction });
 
-    if (karmaTableMapping[reaction]) {
+    if (karmaColumnMapping[reaction]) {
       const expl = await knex('expls').where({ id: explId }).first();
       if (expl.user_id != userId) {
-        await addKarmaStat(expl.user_id, karmaTableMapping[reaction], -1);
+        await addKarmaStat(expl.user_id, karmaColumnMapping[reaction], -1);
       }
     }
 

--- a/src/migrations/20200704153832_add_karma.ts
+++ b/src/migrations/20200704153832_add_karma.ts
@@ -28,6 +28,7 @@ export async function up(knex: Knex): Promise<any> {
     .from('echo_history')
     .innerJoin('expls', 'echo_history.expl_id', 'expls.id')
     .whereRaw('echo_history.user_id != expls.user_id') // Ignore echos to own expls
+    .andWhereRaw('echo_history.was_random = FALSE')
     .groupBy('expls.user_id');
 
   // Combine queries by user_id

--- a/src/migrations/20200704153832_add_karma.ts
+++ b/src/migrations/20200704153832_add_karma.ts
@@ -19,6 +19,7 @@ export async function up(knex: Knex): Promise<any> {
     })
     .from('expls')
     .innerJoin('reactions', 'reactions.expl_id', 'expls.id')
+    .whereRaw('reactions.user_id != expls.user_id') // Ignore reactions to own expls
     .groupBy('expls.user_id');
 
   const echos: any[] = await knex
@@ -26,6 +27,7 @@ export async function up(knex: Knex): Promise<any> {
     .count({ echos: '*' })
     .from('echo_history')
     .innerJoin('expls', 'echo_history.expl_id', 'expls.id')
+    .whereRaw('echo_history.user_id != expls.user_id') // Ignore echos to own expls
     .groupBy('expls.user_id');
 
   // Combine queries by user_id

--- a/src/migrations/20200704153832_add_karma.ts
+++ b/src/migrations/20200704153832_add_karma.ts
@@ -1,0 +1,46 @@
+import * as Knex from 'knex';
+import * as _ from 'lodash';
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.createTable('karma', (t) => {
+    t.string('user_id').primary();
+    t.integer('likes').unsigned().defaultTo(0);
+    t.integer('dislikes').unsigned().defaultTo(0);
+    t.integer('echos').unsigned().defaultTo(0);
+  });
+
+  const reactions: any[] = await knex
+    .select('expls.user_id')
+    .count({
+      likes: knex.raw("CASE reactions.reaction WHEN '👍' THEN 1 ELSE NULL END"),
+      dislikes: knex.raw(
+        "CASE reactions.reaction WHEN '👎' THEN 1 ELSE NULL END",
+      ),
+    })
+    .from('expls')
+    .innerJoin('reactions', 'reactions.expl_id', 'expls.id')
+    .groupBy('expls.user_id');
+
+  const echos: any[] = await knex
+    .select('expls.user_id')
+    .count({ echos: '*' })
+    .from('echo_history')
+    .innerJoin('expls', 'echo_history.expl_id', 'expls.id')
+    .groupBy('expls.user_id');
+
+  // Combine queries by user_id
+  const karma = _.reduce(
+    [...reactions, ...echos],
+    (memo, item) => {
+      memo[item.user_id] = _.assign(memo[item.user_id] || {}, item);
+      return memo;
+    },
+    {} as any,
+  );
+
+  await knex('karma').insert(_.toArray(karma));
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.dropTable('karma');
+}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -471,6 +471,30 @@ describe('Commands', () => {
       expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
     });
 
+    it('calculates karma points from stats correctly', async () => {
+      const stats = {
+        likes: 5,
+        dislikes: 4,
+        echos: 40,
+      };
+
+      await knex('karma').insert({
+        user_id: USER_ID,
+        ...stats,
+      });
+
+      const points =
+        db.KarmaMultipliers.likes * stats.likes +
+        db.KarmaMultipliers.dislikes * stats.dislikes +
+        db.KarmaMultipliers.echos * stats.echos;
+
+      const ctx = message('/karma');
+      await commands.karma(ctx);
+      expect(ctx.reply.lastCall.args[0]).to.equal(
+        messages.karma.display(points),
+      );
+    });
+
     describe("doesn't modify karma on actions to own expls", async () => {
       const EXPL: Partial<Table.Expl> = {
         id: 1,
@@ -484,27 +508,27 @@ describe('Commands', () => {
         await knex('expls').insert(EXPL);
         await db.addReaction(FROM, EXPL.id!, '👍');
 
-        const ctx1 = message('/karma');
-        await commands.karma(ctx1);
-        expect(ctx1.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+        expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
       });
 
       it('dislike', async () => {
         await knex('expls').insert(EXPL);
         await db.addReaction(FROM, EXPL.id!, '👎');
 
-        const ctx2 = message('/karma');
-        await commands.karma(ctx2);
-        expect(ctx2.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+        expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
       });
 
       it('echo', async () => {
         await knex('expls').insert(EXPL);
         db.addEcho(EXPL as any, FROM, false, 1);
 
-        const ctx3 = message('/karma');
-        await commands.karma(ctx3);
-        expect(ctx3.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+        expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
       });
     });
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,12 +1,14 @@
 import 'mocha';
 import { expect } from 'chai';
 import * as _ from 'lodash';
+import * as db from '../src/database';
 import commands from '../src/commands';
 import { MAX_COUNT as MAX_LIST_COUNT } from '../src/commands/list';
 import { AMOUNT_OF_EXPL_OPTIONS } from '../src/commands/quiz';
 import * as messages from '../src/constants/messages';
 import { message, callbackQuery, USER_ID } from './utils/context';
 import { knex, clearDb, migrateAllDown } from './helper';
+import { Table } from '../src/types/database';
 
 describe('Commands', () => {
   beforeEach(clearDb);
@@ -459,6 +461,101 @@ describe('Commands', () => {
 
       expect(ctx.replyWithQuiz.called).not.to.be.true;
       expect(ctx.reply.lastCall.args[0]).to.equal(messages.get.noExpls());
+    });
+  });
+
+  describe.only('/karma', async () => {
+    it('responds even if user has no karma', async () => {
+      const ctx = message('/karma');
+      await commands.karma(ctx);
+      expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+    });
+
+    describe("doesn't count actions to own expls", async () => {
+      const EXPL: Partial<Table.Expl> = {
+        id: 1,
+        key: 'expl_0',
+        value: 'value',
+        user_id: USER_ID,
+      };
+      const FROM = { chat: -1, user: USER_ID };
+
+      it('like', async () => {
+        await knex('expls').insert(EXPL);
+        await db.addReaction(FROM, EXPL.id!, '👍');
+
+        const ctx1 = message('/karma');
+        await commands.karma(ctx1);
+        expect(ctx1.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+      });
+
+      it('dislike', async () => {
+        await knex('expls').insert(EXPL);
+        await db.addReaction(FROM, EXPL.id!, '👎');
+
+        const ctx2 = message('/karma');
+        await commands.karma(ctx2);
+        expect(ctx2.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+      });
+
+      it('echo', async () => {
+        await knex('expls').insert(EXPL);
+        db.addEcho(EXPL as any, FROM, false, 1);
+
+        const ctx3 = message('/karma');
+        await commands.karma(ctx3);
+        expect(ctx3.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+      });
+    });
+
+    describe('modifies karma if someone else reacts to expls', async () => {
+      const EXPL: Partial<Table.Expl> = {
+        id: 1,
+        key: 'expl_0',
+        value: 'value',
+        user_id: USER_ID,
+      };
+
+      const FROM = { chat: -1, user: 223456789 };
+
+      it('like', async () => {
+        await knex('expls').insert(EXPL);
+        await db.addReaction(FROM, EXPL.id!, '👍');
+
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+
+        const karma1 = await db.getUserKarma(USER_ID);
+
+        expect(karma1).to.not.equal(0);
+        expect(ctx.reply.lastCall.args[0]).to.equal(
+          messages.karma.display(karma1),
+        );
+      });
+
+      it('dislike', async () => {
+        await knex('expls').insert(EXPL);
+        await db.addReaction(FROM, EXPL.id!, '👎');
+
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+
+        const karma2 = await db.getUserKarma(USER_ID);
+
+        expect(karma2).to.not.equal(0);
+        expect(ctx.reply.lastCall.args[0]).to.equal(
+          messages.karma.display(karma2),
+        );
+      });
+
+      it('echo', async () => {
+        await knex('expls').insert(EXPL);
+        db.addEcho(EXPL as any, FROM, false, 1);
+
+        const ctx = message('/karma');
+        await commands.karma(ctx);
+        expect(ctx.reply.lastCall.args[0]).to.equal(messages.karma.display(0));
+      });
     });
   });
 });


### PR DESCRIPTION
- Users can see their karma points with `/karma` or `!k`
- User's karma is calculated from user's expls with formula `likes * x + echoes * y - dislikes * z`
- Users can not affect their own karma by reacting or echoing their own expls
- Migrates existing reactions and echos to user's karma
